### PR TITLE
Add php7-simplexml to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN echo "@community https://nl.alpinelinux.org/alpine/v3.6/community" >> /etc/a
     php7-pdo_sqlite@community \
     php7-sqlite3@community \
     php7-ldap@community \
+    php7-simplexml@community \
  && cd /tmp \
  && wget -q https://www.rainloop.net/repository/webmail/rainloop-community-latest.zip \
  && wget -q https://www.rainloop.net/repository/webmail/rainloop-community-latest.zip.asc \


### PR DESCRIPTION
Fixed missing *php7-simplexml* package which is needed to sync contacts with caldav server.
Error: Call to undefined function SabreForRainLoop\DAV\simplexml_load_string()