### PR TITLE
Make NginX to listen on IPv6 port as well

### DIFF
--- a/rootfs/etc/nginx/nginx.conf
+++ b/rootfs/etc/nginx/nginx.conf
@@ -52,7 +52,7 @@ http {
     image/svg+xml;
 
   server {
-    listen 8888;
+    listen [::]:8888;
     root /rainloop;
     index index.php;
     charset utf-8;


### PR DESCRIPTION
IPv6 is evolving and many sites need to listen on IPv6 ports (even in docker).

Of course, this change will not harm the now-working IPv4 stuffs.