### PR TITLE
Added switch to activate logging to STDOUT

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Rainloop is a simple, modern & fast web-based client. More details on the [offic
 | **UID** | rainloop user id | *optional* | 991
 | **GID** | rainloop group id | *optional* | 991
 | **UPLOAD_MAX_SIZE** | Attachment size limit | *optional* | 25M
+| **LOG_TO_STDOUT** | set to "true" | *optional* | undef
 
 ### Docker-compose.yml
 

--- a/rootfs/usr/local/bin/run.sh
+++ b/rootfs/usr/local/bin/run.sh
@@ -11,7 +11,7 @@ fi
 # Set log output to STDOUT if wanted (LOG_TO_STDOUT=true)
 if [ "$LOG_TO_STDOUT" == "true" ]; then
   chmod o+w /dev/stdout
-  sed -i "s/.*error_log.*$/error_log /dev/stdout warn;/"
+  sed -i "s/.*error_log.*$/error_log \/dev\/stdout warn;/"
   echo "Logging to STDOUT activated" > /dev/stdout
 fi
 

--- a/rootfs/usr/local/bin/run.sh
+++ b/rootfs/usr/local/bin/run.sh
@@ -8,7 +8,7 @@ if [ -d "/rainloop/data/_data_/_default_/plugins/postfixadmin-change-password" ]
   rm -rf /rainloop/data/_data_/_default_/plugins/postfixadmin-change-password
 fi
 
-# Set log output to STDOUT if wanted (NGINX_LOG_TO_STDOUT=true)
+# Set log output to STDOUT if wanted (LOG_TO_STDOUT=true)
 if [ "$LOG_TO_STDOUT" == "true" ]; then
   chmod o+w /dev/stdout
   sed -i "s/.*error_log.*$/error_log /dev/stdout warn;/"

--- a/rootfs/usr/local/bin/run.sh
+++ b/rootfs/usr/local/bin/run.sh
@@ -8,6 +8,13 @@ if [ -d "/rainloop/data/_data_/_default_/plugins/postfixadmin-change-password" ]
   rm -rf /rainloop/data/_data_/_default_/plugins/postfixadmin-change-password
 fi
 
+# Set log output to STDOUT if wanted (NGINX_LOG_TO_STDOUT=true)
+if [ "$LOG_TO_STDOUT" == "true" ]; then
+  chmod o+w /dev/stdout
+  sed -i "s/.*error_log.*$/error_log /dev/stdout warn;/"
+  echo "Logging to STDOUT activated" > /dev/stdout
+fi
+
 # Add postfixadmin-change-password plugin
 mkdir -p /rainloop/data/_data_/_default_/plugins/
 cp -r /usr/local/include/postfixadmin-change-password /rainloop/data/_data_/_default_/plugins/

--- a/rootfs/usr/local/bin/run.sh
+++ b/rootfs/usr/local/bin/run.sh
@@ -11,7 +11,7 @@ fi
 # Set log output to STDOUT if wanted (LOG_TO_STDOUT=true)
 if [ "$LOG_TO_STDOUT" == "true" ]; then
   chmod o+w /dev/stdout
-  sed -i "s/.*error_log.*$/error_log \/dev\/stdout warn;/"
+  sed -i "s/.*error_log.*$/error_log \/dev\/stdout warn;/" /etc/nginx/nginx.conf
   echo "Logging to STDOUT activated" > /dev/stdout
 fi
 


### PR DESCRIPTION
# What is this?
Because of the expected default behavior in Docker environments, I added the ability to send logs of the container / daemon to stdout to see what's going on.
## How to to
Simply set an environment variable
# Please check and comment
